### PR TITLE
[NN-368] инкремент external_id при кроне. 

### DIFF
--- a/app/code/community/Mygento/Kkm/AtolException.php
+++ b/app/code/community/Mygento/Kkm/AtolException.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ *
+ *
+ * @category Mygento
+ * @package Mygento_Kkm
+ * @copyright 2018 NKS LLC. (https://www.mygento.ru)
+ */
+class Mygento_Kkm_AtolException extends Exception
+{
+
+}

--- a/app/code/community/Mygento/Kkm/SendingException.php
+++ b/app/code/community/Mygento/Kkm/SendingException.php
@@ -4,8 +4,8 @@
  *
  *
  * @category Mygento
- * @package Mygento_projects
- * @copyright 2017 NKS LLC. (https://www.mygento.ru)
+ * @package Mygento_Kkm
+ * @copyright 2018 NKS LLC. (https://www.mygento.ru)
  */
 class Mygento_Kkm_SendingException extends Exception
 {


### PR DESCRIPTION
Исправлена обрарботка транзакции если код ошибки = 10 (Already exists)
Комент, который должен был только в ордер записываться - записывался в БД в таблицу mygento_kkm_status при падании дедлоков