### PR TITLE
Fix compatibility error for php8.3 syntax

### DIFF
--- a/.github/workflows/grumphp.yml
+++ b/.github/workflows/grumphp.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.1']
+        php-versions: ['7.4', '8.1', '8.3']
     steps:
       - uses: actions/checkout@v2
 

--- a/Console/UpdateStatus.php
+++ b/Console/UpdateStatus.php
@@ -109,7 +109,7 @@ class UpdateStatus extends Command
 
             $uuids = $this->transactionHelper->getWaitUuidsByStore($store->getId());
             foreach ($uuids as $uuid) {
-                $output->writeln("<comment>${i} Updating {$uuid} ...</comment>");
+                $output->writeln("<comment>{$i} Updating {$uuid} ...</comment>");
                 $this->updateOne($output, $uuid);
                 $i++;
             }


### PR DESCRIPTION
Сhange syntax ${variable} to {$variable}